### PR TITLE
fix: flag for local vs remote init was wrong

### DIFF
--- a/exports/Taskfile.dist.yaml
+++ b/exports/Taskfile.dist.yaml
@@ -53,7 +53,7 @@ tasks:
 
       - |
         echo -e "\n"
-        if [[ -z "{{.TASKIT_LOCAL_PATH}}" ]]; then
+        if [[ -n "{{.TASKIT_LOCAL_PATH}}" ]]; then
           echo "Copying taskit from local path..."
           rsync -rq --exclude=.git --exclude= {{.TASKIT_LOCAL_PATH}} .taskit
         else

--- a/exports/Taskfile.dist.yaml
+++ b/exports/Taskfile.dist.yaml
@@ -58,7 +58,7 @@ tasks:
           rsync -rq --exclude=.git --exclude= {{.TASKIT_LOCAL_PATH}} .taskit
         else
           echo "Downloading taskit from remote repo..."
-          git clone -b {{.TASKIT_BRANCH}} git@github.com:masterpointio/taskit.git .taskit
+          git clone -b {{.TASKIT_BRANCH}} https://github.com/masterpointio/taskit.git .taskit
         fi
 
         echo -e "\n\n⚡ Taskit successfully initialized! ⚡\n"

--- a/lib/snaplet/Taskfile.yaml
+++ b/lib/snaplet/Taskfile.yaml
@@ -9,6 +9,7 @@ vars:
   SNAPSHOT_NAME:
     sh: date +%Y-%m-%d # YYYY-MM-DD
   SNAPSHOT_PATH: ".snaplet/snapshots/{{.SNAPSHOT_NAME}}"
+  SNAPSHOT_ENV: dev
 
 tasks:
   validate-snaplet-bucket-access:
@@ -70,13 +71,14 @@ tasks:
     requires:
       vars:
         - SNAPLET_BUCKET
+        - SNAPSHOT_ENV
     cmds:
-      - aws s3 cp --sse=AES256 --recursive {{.SNAPSHOT_PATH}} {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_NAME}}
+      - aws s3 cp --sse=AES256 --recursive {{.SNAPSHOT_PATH}} {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/{{.SNAPSHOT_NAME}}
       - |
         if [ "{{.UPLOAD_AS_LATEST}}" -eq "true" ]; then
           # We first remove everything so there are no artifacts leftover from a previous upload that we're not overwriting.
-          aws s3 rm --recursive {{.SNAPLET_BUCKET}}/latest
-          aws s3 cp --sse=AES256 --recursive {{.SNAPSHOT_PATH}} {{.SNAPLET_BUCKET}}/latest
+          aws s3 rm --recursive {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/latest
+          aws s3 cp --sse=AES256 --recursive {{.SNAPSHOT_PATH}} {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/latest
         fi
 
   download:
@@ -91,8 +93,9 @@ tasks:
     requires:
       vars:
         - SNAPLET_BUCKET
+        - SNAPSHOT_ENV
     cmds:
-      - aws s3 cp --quiet --sse=AES256 --recursive {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_NAME}} {{.SNAPSHOT_PATH}}
+      - aws s3 cp --quiet --sse=AES256 --recursive {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/{{.SNAPSHOT_NAME}} {{.SNAPSHOT_PATH}}
       - printf "\n\n⬇ Snapshot downloaded to {{.SNAPSHOT_PATH}}"
 
   restore:


### PR DESCRIPTION
## Info

* local vs remote flag in init: This was broken and never working. Realized within client project. 
* Updates to use `https` git clone instead of `ssh` as SSH did not work in GHAs without creating a user and all that jazz. We may need to get more complicated here in the future, but hopefully not. 
* Adds `SNAPSHOT_ENV` var to snaplet snapshot paths (via `upload` and `download` tasks) in S3 for differentiating dev vs stage vs prod vs whatever snapshots. 

* We need tests for this stuff... https://github.com/go-task/task/discussions/1283