### PR TITLE
fix: renames snaplet vars to avoid collisions

### DIFF
--- a/lib/snaplet/Taskfile.yaml
+++ b/lib/snaplet/Taskfile.yaml
@@ -96,29 +96,36 @@ tasks:
         fi
 
   download:
-    desc: Downloads a snaplet snapshot from a given S3 Bucket. Pass in SNAPSHOT_NAME to download a specific snapshot from the bucket.
+    desc: Downloads a snaplet snapshot to the local machine.
+    summary: |
+      Downloads a given snaplet snapshot from a given S3 Bucket.
+      Pass in RESTORE_SNAPSHOT to download a specific snapshot from the bucket.
+      Pass in SNAPSHOT_ENV to download the snapshot for a specific environment.
+      Pass in SNAPLET_BUCKET to download from a specific bucket.
     silent: true
     deps:
-      - clean
-      - validate-snaplet-bucket-access
+      - task: clean
+        vars:
+          SNAPSHOT_PATH: "{{.SNAPSHOT_PATH}}"
+      - task: validate-snaplet-bucket-access
     vars:
-      SNAPSHOT_NAME: '{{.SNAPSHOT_NAME | default "latest"}}'
-      SNAPSHOT_PATH: ".snaplet/snapshots/{{.SNAPSHOT_ENV}}/{{.SNAPSHOT_NAME}}"
+      RESTORE_SNAPSHOT: '{{.RESTORE_SNAPSHOT | default "latest"}}'
+      SNAPSHOT_PATH: ".snaplet/snapshots/{{.SNAPSHOT_ENV}}/{{.RESTORE_SNAPSHOT}}"
     requires:
       vars:
         - SNAPLET_BUCKET
         - SNAPSHOT_ENV
     cmds:
-      - aws s3 cp --quiet --sse=AES256 --recursive {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/{{.SNAPSHOT_NAME}} {{.SNAPSHOT_PATH}}
-      - printf "\n\n⬇ Snapshot downloaded to {{.SNAPSHOT_PATH}}"
+      - aws s3 cp --quiet --sse=AES256 --recursive {{.SNAPLET_BUCKET}}/{{.SNAPSHOT_ENV}}/{{.RESTORE_SNAPSHOT}} {{.SNAPSHOT_PATH}}
+      - printf "\n\n⬇ Snapshot downloaded to {{.SNAPSHOT_PATH}}\n\n"
 
   restore:
-    desc: Restores the given SNAPSHOT_NAME to the SNAPLET_TARGET_DATABASE_URL database.
+    desc: Restores the given RESTORE_SNAPSHOT to the SNAPLET_TARGET_DATABASE_URL database.
     prompt: This will wipe all of the data in the given SNAPLET_TARGET_DATABASE_URL. Are you sure?
     silent: true
     vars:
-      SNAPSHOT_NAME: '{{.SNAPSHOT_NAME | default "latest"}}'
-      SNAPSHOT_PATH: .snaplet/snapshots/{{.SNAPSHOT_ENV}}/{{.SNAPSHOT_NAME}}
+      RESTORE_SNAPSHOT: '{{.RESTORE_SNAPSHOT | default "latest"}}'
+      SNAPSHOT_PATH: .snaplet/snapshots/{{.SNAPSHOT_ENV}}/{{.RESTORE_SNAPSHOT}}
     requires:
       vars:
         - SNAPLET_TARGET_DATABASE_URL

--- a/lib/toolbox/Taskfile.yaml
+++ b/lib/toolbox/Taskfile.yaml
@@ -7,7 +7,7 @@ vars:
   VERSION:
     sh: git rev-parse --short HEAD
   REGISTRY_URL_FULL: "{{.REGISTRY_URL}}/{{.LATEST_IMAGE_TAG}}"
-  CONTAINERFILE_PATH: ./Dockerfile
+  CONTAINERFILE_PATH: '{{.CONTAINERFILE_PATH | default "./Dockerfile"}}'
   AWS_REGION: '{{.AWS_REGION | default "us-east-1"}}'
 
 tasks:
@@ -25,7 +25,7 @@ tasks:
         - IMAGE_NAME
         - CONTAINERFILE_PATH
     cmds:
-      - docker build --tag {{.LASTEST_IMAGE_TAG}} --tag {{.VERSION_IMAGE_TAG}} {{.CONTAINERFILE_PATH}}
+      - "docker build --tag {{.LATEST_IMAGE_TAG}} --tag {{.VERSION_IMAGE_TAG}} -f {{.CONTAINERFILE_PATH}} ."
       - echo "Done building and tagging toolbox 💯 Tagged as {{.VERSION_IMAGE_TAG}} + {{.LATEST_IMAGE_TAG}}"
 
   install:
@@ -50,7 +50,7 @@ tasks:
   run:
     desc: Run our toolbox image while also mounting your $HOME folder to `/localhost` in the container
     cmds:
-      - /usr/local/bin/{{.IMAGE_NAME}}
+      - "{{.IMAGE_NAME}}"
 # TODO
 # ## Publish the toolbox image to our ECR repo
 # publish: build


### PR DESCRIPTION
## Info

* Updates snaplet var `SNAPSHOT_NAME` to not be used in the `snaplet:download` or `snaplet:restore` tasks as that was causing collisions and wasn't allowing us to overwrite those vars. Updates those vars to `RESTORE_SNAPSHOT` which keeps it unique and helps avoid the issue. 
* Updates the toolbox tasks a tiny bit, but this is still a WIP. 