### PR TITLE
feat: moves Terraform + mixin tasks to where they belong

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,9 +1,13 @@
 version: "3"
 
 includes:
-  aqua: lib/aqua/Taskfile.yaml
-  aws: lib/aws/Taskfile.yaml
-  snaplet: lib/snaplet/Taskfile.yaml
-  toolbox: lib/toolbox/Taskfile.yaml
+  aqua: lib/aqua
+  aws: lib/aws
+  mixins: lib/mixins
+  snaplet: lib/snaplet
+  terraform:
+    taskfile: lib/terraform
+    aliases: [tf]
+  toolbox: lib/toolbox
 
 tasks: {}

--- a/lib/mixins/Taskfile.yml
+++ b/lib/mixins/Taskfile.yml
@@ -1,0 +1,35 @@
+version: "3"
+
+tasks:
+  update-all:
+    desc: "Update a mixin across the components. Example: `task mixins:update-all -- context.tf`."
+    preconditions:
+      - sh: test -f ./mixins/{{.CLI_ARGS}}
+        msg: "File does not exist: ./mixins/{{.CLI_ARGS}}"
+      - sh: test -d ./components && [ "$(ls -A ./components)" ]
+        msg: ./components/ directory is empty or does not exist.
+    sources:
+      - ./mixins/{{.CLI_ARGS}}
+    generates:
+      - ./components/*/{{.CLI_ARGS}}
+    cmds:
+      - cmd: |
+          for comp in ./components/*; do
+            cp -v ./mixins/{{.CLI_ARGS}}  $comp/{{.CLI_ARGS}}
+          done;
+        silent: true
+
+  pull-sops:
+    desc: Pull SOPS secrets mixin from its external source into the working directory.
+    dir: "{{.USER_WORKING_DIR}}"
+    silent: true
+    env:
+      MIXIN_FILE: secrets.sops.tf
+    cmds:
+      - echo "Pulling secrets mixin from 'masterpointio/terraform-secrets-helper' Git repo..."
+      - |
+        if curl -sL https://raw.githubusercontent.com/masterpointio/terraform-secrets-helper/main/exports/$MIXIN_FILE -o $MIXIN_FILE; then
+            echo "File $MIXIN_FILE was successfully pulled."
+        else
+            echo "File $MIXIN_FILE pull failed."
+        fi;

--- a/lib/terraform/Taskfile.yml
+++ b/lib/terraform/Taskfile.yml
@@ -1,0 +1,76 @@
+version: "3"
+
+vars:
+  BACKEND_CONFIG_PATH: '{{.BACKEND_CONFIG_PATH | default "./backend-configurations"}}'
+  TFVARS_PATH: '{{.TFVARS_PATH | default "./tfvars"}}'
+
+tasks:
+  setup:
+    desc: Internal task to templatize the variables for the other tasks.
+    summary: |
+      This is a workaround for the lack of support for sharing variables between the tasks for the sake of DRY.
+      1. Global vars are being evaluated when the Taskfile.yml is first loaded and at that time,
+        `.CLI_ARGS` is not yet available, that's why we have to duplicate the variables for every task.
+      2. Taskfile commands run in their own shell environments, so if you set an environment variable in one task,
+        it won't persist after that task completes or be available in other tasks.
+    silent: true
+    internal: true
+    vars: &vars
+      ENV:
+        sh: echo "{{.CLI_ARGS}}" | cut -d ' ' -f1 | xargs
+      TF_ARGS:
+        sh: echo "{{.CLI_ARGS}}" | cut -s -d ' ' -f2- | xargs
+      BACKEND_CONFIG_FILE:
+        sh: echo "{{.BACKEND_CONFIG_PATH}}/{{.ENV}}.backend.tf"
+      TFVARS_FILE:
+        sh: echo "{{.TFVARS_PATH}}/{{.ENV}}.tfvars"
+
+  init:
+    desc: Initialize Terraform working directory with a backend configuration file.
+    summary: |
+      Initializes Terraform directory using the backend config file for the specified environment.
+      The `terraform init` arguments can be optionally passed in.
+      Usage: task terraform:init -- ENVIRONMENT [terraform init arguments]
+      Example: task terraform:init -- automation
+    dir: "{{.USER_WORKING_DIR}}"
+    silent: true
+    vars: *vars
+    preconditions:
+      - sh: test -f {{.BACKEND_CONFIG_FILE}}
+        msg: "Backend configuration file does not exist: {{.BACKEND_CONFIG_FILE}}"
+    cmds:
+      - terraform init -backend-config {{.BACKEND_CONFIG_FILE}} {{.TF_ARGS}}
+
+  plan:
+    desc: Generate a Terraform execution plan Terraform loading variable values from the given file.
+    summary: |
+      Generates a Terraform execution plan for a specified environment, using a file to load the variables.
+      The `terraform plan` arguments can be optionally passed in.
+      Requires a variables file specific to the environment to be present.
+      Usage: task terraform:plan -- ENVIRONMENT [terraform plan arguments]
+      Example: task terraform:plan -- automation
+    dir: "{{.USER_WORKING_DIR}}"
+    silent: true
+    vars: *vars
+    preconditions:
+      - sh: test -f {{.TFVARS_FILE}}
+        msg: "Variables file does not exist: {{.TFVARS_FILE}}"
+    cmds:
+      - terraform plan -var-file {{.TFVARS_FILE}} {{.TF_ARGS}}
+
+  apply:
+    desc: Create or update infrastructure according to Terraform configuration files in the current directory.
+    summary: |
+      Applies a Terraform execution plan for a specific environment, using a file to load the variables.
+      The `terraform apply` arguments can be optionally passed in.
+      Requires a variables file specific to the environment to be present.
+      Usage: task terraform:apply -- ENVIRONMENT [terraform apply arguments]
+      Example: task terraform:apply -- automation
+    dir: "{{.USER_WORKING_DIR}}"
+    silent: true
+    vars: *vars
+    preconditions:
+      - sh: test -f {{.TFVARS_FILE}}
+        msg: "Variables file does not exist: {{.TFVARS_FILE}}"
+    cmds:
+      - terraform apply -var-file {{.TFVARS_FILE}} {{.TF_ARGS}}


### PR DESCRIPTION
## Info
* Moves Terraform + mixin tasks for `mp-infra` repo with small improvements. Sister PR in `mp-infra` will be up soon.
* Adds `pull-sops` task to support secrets mixin management (SOPS only for now).
* Removes Taskfile filenames from the root `Taskfile.yaml` to keep it nice.