### PR TITLE
feat: adds a restore:noprompt task

### DIFF
--- a/exports/Taskfile.dist.yaml
+++ b/exports/Taskfile.dist.yaml
@@ -57,7 +57,7 @@ tasks:
         echo -e "\n"
         if [[ -n "{{.TASKIT_LOCAL_PATH}}" ]]; then
           echo "Copying taskit from local path..."
-          rsync -rq --exclude=.git --exclude= {{.TASKIT_LOCAL_PATH}} .taskit
+          rsync -rq --exclude=.git --exclude= {{.TASKIT_LOCAL_PATH}}/ .taskit
         else
           echo "Downloading taskit from remote repo..."
           git clone -b {{.TASKIT_BRANCH}} https://github.com/masterpointio/taskit.git .taskit/

--- a/lib/snaplet/Taskfile.yaml
+++ b/lib/snaplet/Taskfile.yaml
@@ -146,6 +146,6 @@ tasks:
     cmds:
       - task: restore
         vars:
-          RESTORE_OPTIONS: --yes
+          RESTORE_OPTIONS: --yes --no-progress
           RESTORE_SNAPSHOT: "{{.RESTORE_SNAPSHOT}}"
           SNAPSHOT_PATH: "{{.SNAPSHOT_PATH}}"

--- a/lib/snaplet/Taskfile.yaml
+++ b/lib/snaplet/Taskfile.yaml
@@ -121,7 +121,21 @@ tasks:
 
   restore:
     desc: Restores the given RESTORE_SNAPSHOT to the SNAPLET_TARGET_DATABASE_URL database.
-    prompt: This will wipe all of the data in the given SNAPLET_TARGET_DATABASE_URL. Are you sure?
+    silent: true
+    vars:
+      RESTORE_OPTIONS: '{{.RESTORE_OPTIONS | default ""}}'
+      RESTORE_SNAPSHOT: '{{.RESTORE_SNAPSHOT | default "latest"}}'
+      SNAPSHOT_PATH: .snaplet/snapshots/{{.SNAPSHOT_ENV}}/{{.RESTORE_SNAPSHOT}}
+    requires:
+      vars:
+        - SNAPLET_TARGET_DATABASE_URL
+    cmds:
+      - printf "\n\n👋 Restoring snapshot from {{.SNAPSHOT_PATH}}\n"
+      - snaplet snapshot restore {{.RESTORE_OPTIONS}} {{.SNAPSHOT_PATH}}
+      - printf "\n\n💯 Restored snapshot from {{.SNAPSHOT_PATH}}\n"
+
+  restore:noprompt:
+    desc: Restores the given RESTORE_SNAPSHOT to the SNAPLET_TARGET_DATABASE_URL database.
     silent: true
     vars:
       RESTORE_SNAPSHOT: '{{.RESTORE_SNAPSHOT | default "latest"}}'
@@ -130,6 +144,8 @@ tasks:
       vars:
         - SNAPLET_TARGET_DATABASE_URL
     cmds:
-      - printf "\n\n👋 Restoring snapshot from {{.SNAPSHOT_PATH}}\n"
-      - snaplet snapshot restore {{.SNAPSHOT_PATH}}
-      - printf "\n\n💯 Restored snapshot from {{.SNAPSHOT_PATH}}\n"
+      - task: restore
+        vars:
+          RESTORE_OPTIONS: --yes
+          RESTORE_SNAPSHOT: "{{.RESTORE_SNAPSHOT}}"
+          SNAPSHOT_PATH: "{{.SNAPSHOT_PATH}}"


### PR DESCRIPTION
## Info

* Adds a new `restore:noprompt` task for calling `snaplet restore` via CI
* Removes the prompt from `restore` task since it's a dup of what snaplet does. 