### PR TITLE
chore: add new postgres module to sync repo list

### DIFF
--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -8,7 +8,7 @@ vars:
     terraform-github-teams \
     terraform-github-organization \
     terraform-googleworkspace-users-groups-automation \
-    terraform-postgres-automation \
+    terraform-postgres-config-dbs-users-roles \
     terraform-secrets-helper \
     terraform-spacelift-automation \
     terraform-spacelift-aws-integrations \


### PR DESCRIPTION
## what
- add postgres module to list of repos for template sync process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default list of Terraform modules to replace one module with another, affecting which modules are processed by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->