### PR TITLE
feat: small solutions for running task os:sync-all

### DIFF
--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -8,7 +8,7 @@ vars:
     terraform-github-teams \
     terraform-github-organization \
     terraform-googleworkspace-users-groups-automation \
-    terraform-postgres-automation \
+    terraform-postgres-config-dbs-users-roles \
     terraform-secrets-helper \
     terraform-spacelift-automation \
     terraform-spacelift-aws-integrations \

--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -67,19 +67,41 @@ tasks:
 
     vars:
       MODULES: "{{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}{{.DEFAULT_MODULES}}{{end}}"
+      DELETE_EXISTING_SYNC_BRANCH: "{{.DELETE_EXISTING_SYNC_BRANCH | default false}}"
     cmds:
       - |
         # Convert newlines to spaces and remove backslashes
         modules=$(echo "{{.MODULES}}" | tr '\n' ' ' | sed 's/\\//g')
         for module in $modules
         do
-          echo "🚀 Processing ../$module..."
+          echo -e "\n\n🚀 Processing ---------------- $module \n"
+          if [ ! -d ../$module ]; then
+            echo "🧲 Cloning repository..."
+            git clone "git@github.com:masterpointio/$module.git" ../$module
+          fi
           cd ../$module
-          echo "⬇️ Pulling main branch..."
+
+          echo "⬇️  Pulling main branch..."
           git checkout main
           git pull origin main
-          echo "🔄 Creating sync branch..."
-          git checkout -b {{.SYNC_BRANCH}}
+
+          echo "🔄 Creating sync branch ..."
+
+          # If branch exists and delete option is turned off - skip creation
+          if git branch --list "{{.SYNC_BRANCH}}" | grep -q "{{.SYNC_BRANCH}}" && [ "{{.DELETE_EXISTING_SYNC_BRANCH}}" = "false" ]; then
+            echo "⏭️  Branch {{.SYNC_BRANCH}} already exists, skipping creation."
+
+          # If branch exists and delete option is turned on - delete and create new branch
+          elif git branch --list "{{.SYNC_BRANCH}}" | grep -q "{{.SYNC_BRANCH}}" && [ "{{.DELETE_EXISTING_SYNC_BRANCH}}" = "true" ]; then
+            echo "⏭️  Branch {{.SYNC_BRANCH}} already exists, deleting it."
+            git branch -D {{.SYNC_BRANCH}}
+            git checkout -b {{.SYNC_BRANCH}}
+
+          # If branch does not exist - create new branch
+          else
+            git checkout -b {{.SYNC_BRANCH}}
+          fi
+
           cd -
         done
 
@@ -138,6 +160,7 @@ tasks:
 
     vars:
       MODULES: "{{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}{{.DEFAULT_MODULES}}{{end}}"
+      DELETE_EXISTING_SYNC_BRANCH: "{{.DELETE_EXISTING_SYNC_BRANCH | default false}}"
     cmds:
       - task: setup-template
       - task: pull-and-branch


### PR DESCRIPTION
## what
- I ran into an issue where the process would fail if I had not already cloned the `DEFAULT_MODULES` repos. I added a graceful response where we git clone the repos for the user.
- I wasn't able to run the sync process because there were existing git branches from a previous sync. To handle this, I added a global variable, `DELETE_EXISTING_SYNC_BRANCH`, defaulting to `false` (to keep existing workflow) so the process conditionally deletes the `SYNC_BRANCH` and creates a new `SYNC_BRANCH`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control whether existing sync branches are deleted when syncing repositories.
- **Enhancements**
  - Improved handling of repository cloning and branch creation, including additional logging for clarity.
  - Updated the default module list to include a new module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->