### PR TITLE
fix(snaplet): add snaplet target DB var to SNAPSHOT_PATHs

### DIFF
--- a/lib/snaplet/Taskfile.yaml
+++ b/lib/snaplet/Taskfile.yaml
@@ -124,6 +124,8 @@ tasks:
   restore:
     desc: Restores the given RESTORE_SNAPSHOT to the SNAPLET_TARGET_DATABASE_URL database.
     silent: true
+    env:
+      SNAPLET_TARGET_DATABASE_URL: "{{.SNAPLET_TARGET_DATABASE_URL}}"
     vars:
       RESTORE_OPTIONS: '{{.RESTORE_OPTIONS | default ""}}'
       RESTORE_SNAPSHOT: '{{.RESTORE_SNAPSHOT | default "latest"}}'


### PR DESCRIPTION
Follow up to a previous PR https://github.com/masterpointio/taskit/pull/13 where support for `SNAPLET_TARGET_DB_NAME` was added, where there are use cases when using the same Taskfile commands, but for different DB connections and DB names. 

The `SNAPSHOT_PATH` where the snapshots are stored, did not have the `SNAPLET_TARGET_DB_NAME` identifier. This PR adds that. 

This is needed because if storing multiple DB snapshots, all snapshots are stored in the same directory of the  .SNAPSHOT_ENV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated snapshot storage paths to include the database name for improved organization when downloading or restoring snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->