### PR TITLE
feat: add linter configs to the os sync task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .cursor/rules/*
+
+# Claude Code - we beleive engineers are responsible for the code they push no matter how it's generated.
+# Therefore, configs specific to their coding practices are their responsibilty to judiciously manage.
+.claude/*
+

--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -2,18 +2,7 @@ version: "3"
 
 vars:
   DEFAULT_MODULES: |
-    terraform-aws-ssm-agent \
-    terraform-aws-tailscale \
-    terraform-datadog-users \
-    terraform-github-teams \
-    terraform-github-organization \
-    terraform-googleworkspace-users-groups-automation \
-    terraform-postgres-config-dbs-users-roles \
-    terraform-secrets-helper \
-    terraform-spacelift-automation \
-    terraform-spacelift-aws-integrations \
-    terraform-spacelift-events-collector-audit-trail \
-    terraform-spacelift-policies
+    terraform-googleworkspace-users-groups-automation
   SYNC_BRANCH: chore/sync-with-template
   SHARED_TMP_DIR: .tmp-template-sync
 tasks:
@@ -40,13 +29,17 @@ tasks:
         .terraform-docs.yaml
         LICENSE
         aqua.yaml
+        .tflint.hcl
+        .checkov.yaml
+        .yamllint.yaml
+        .markdownlint.yaml
     cmds:
       - |
         # Convert newlines to spaces and remove backslashes
         modules=$(echo "{{.MODULES}}" | tr '\n' ' ' | sed 's/\\//g')
         for module in $modules
         do
-          echo "Syncing files to ../$module..."
+          echo "Syncing files to ../$module ..."
           for file in {{.FILES}}
           do
             echo "  Syncing $file"

--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -32,18 +32,18 @@ tasks:
     vars:
       MODULES: "{{if .CLI_ARGS}}{{.CLI_ARGS}}{{else}}{{.DEFAULT_MODULES}}{{end}}"
       FILES: >-
-        .github
-        .trunk
+        .checkov.yaml
         .coderabbit.yaml
         .editorconfig
         .gitignore
+        .github
+        .markdownlint.yaml
         .terraform-docs.yaml
+        .tflint.hcl
+        .trunk
+        .yamllint.yaml
         LICENSE
         aqua.yaml
-        .tflint.hcl
-        .checkov.yaml
-        .yamllint.yaml
-        .markdownlint.yaml
     cmds:
       - |
         # Convert newlines to spaces and remove backslashes

--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -2,7 +2,18 @@ version: "3"
 
 vars:
   DEFAULT_MODULES: |
-    terraform-googleworkspace-users-groups-automation
+    terraform-aws-ssm-agent \
+    terraform-aws-tailscale \
+    terraform-datadog-users \
+    terraform-github-organization \
+    terraform-github-teams \
+    terraform-googleworkspace-users-groups-automation \
+    terraform-postgres-config-dbs-users-roles \
+    terraform-secrets-helper \
+    terraform-spacelift-automation \
+    terraform-spacelift-aws-integrations \
+    terraform-spacelift-events-collector-audit-trail \
+    terraform-spacelift-policies
   SYNC_BRANCH: chore/sync-with-template
   SHARED_TMP_DIR: .tmp-template-sync
 tasks:


### PR DESCRIPTION
## what
- sync linter configs from template repo when
- See this for more context https://github.com/masterpointio/terraform-module-template/pull/44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the default set of modules to target only one specific module.
	- Expanded the list of configuration files included in synchronization tasks.
	- Improved comments and ignore patterns for project-specific directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->