### PR TITLE
chore: add new mp open source tf repo in task

### DIFF
--- a/lib/os-modules/Taskfile.yaml
+++ b/lib/os-modules/Taskfile.yaml
@@ -4,6 +4,7 @@ vars:
   DEFAULT_MODULES: |
     terraform-aws-ssm-agent \
     terraform-aws-tailscale \
+    terraform-aws-identity-center-users \
     terraform-datadog-users \
     terraform-github-organization \
     terraform-github-teams \


### PR DESCRIPTION
https://github.com/masterpointio/terraform-aws-identity-center-users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the `terraform-aws-identity-center-users` module to the default list of Terraform modules targeted by automated tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->