### PR TITLE
feat: allow backend role arn to init (AIR-1495)

### DIFF
--- a/lib/tf/Taskfile.yml
+++ b/lib/tf/Taskfile.yml
@@ -25,6 +25,8 @@ tasks:
         sh: echo "{{.TFVARS_PATH}}/{{.WORKSPACE}}.tfvars"
       TF_CMD:
         sh: '[ "${USE_TERRAFORM}" = "true" ] && echo "terraform" || echo "tofu"'
+      TF_BACKEND_ROLE_ARN:
+        sh: echo "${TF_BACKEND_ROLE_ARN:-}"
 
   init:
     desc: Initialize Terraform or OpenTofu working directory.
@@ -37,7 +39,7 @@ tasks:
     silent: true
     vars: *vars
     cmds:
-      - "{{.TF_CMD}} init {{.TF_ARGS}}"
+      - '{{.TF_CMD}} init {{if .TF_BACKEND_ROLE_ARN}}-backend-config="role_arn={{.TF_BACKEND_ROLE_ARN}}" {{end}}{{.TF_ARGS}}'
 
   plan:
     desc: Generate a Terraform or OpenTofu execution plan, loading variable values from the given file.


### PR DESCRIPTION
## what

- Allow a backend role arn to be used during `init`

## why

- We've had interest in using a backend role for local tf operations, as an alternative to defining an `assume_role` within backend config or relying on ambient credentials. 

## references

- [AIR-1495](https://www.notion.so/masterpoint/Ensure-mp-infra-demonstrates-read-only-vs-write-role-separation-for-Spacelift-backend-access-as-refe-342859758a56816a8d9cd9080ed989e8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backend role ARN configuration is now supported through environment variables during initialization, providing greater flexibility for infrastructure deployments. This enhancement streamlines multi-environment setup workflows and eliminates the need for code modifications when managing backend configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->