### PR TITLE
feat(mixins): recurse into nested modules and only update existing copies

### DIFF
--- a/lib/mixins/Taskfile.yml
+++ b/lib/mixins/Taskfile.yml
@@ -2,21 +2,32 @@ version: "3"
 
 tasks:
   update-all:
-    desc: "Update a mixin across the components. Example: `task mixins:update-all -- context.tf`."
+    # Updates (by overwriting) every existing copy of the named mixin under
+    # ./components/ with the current ./mixins/<file> template.
+    #
+    # Directories opt in to a mixin by having a copy of it on disk; this task only
+    # touches directories that already contain <file>. It does NOT add the mixin
+    # to directories that don't already have it — adopt a mixin in a new component
+    # by copying it in manually first as it needs to be an explicit choice, then
+    # future `update-all` runs will keep it in sync.
+    #
+    # `.terraform/` and `.terragrunt-cache/` are pruned so we don't overwrite the
+    # mixin inside vendored child-module copies that Terraform/Terragrunt drop on
+    # disk during init.
+    desc: "Update (by overwriting) every existing copy of a mixin under ./components/ with the current template. Does not add the mixin to directories that don't already have it. Example: `task mixins:update-all -- context.tf`."
+    dir: "{{.USER_WORKING_DIR}}"
     preconditions:
       - sh: test -f ./mixins/{{.CLI_ARGS}}
         msg: "File does not exist: ./mixins/{{.CLI_ARGS}}"
-      - sh: test -d ./components && [ "$(ls -A ./components)" ]
-        msg: ./components/ directory is empty or does not exist.
+      - sh: test -d ./components
+        msg: ./components/ directory does not exist.
     sources:
       - ./mixins/{{.CLI_ARGS}}
-    generates:
-      - ./components/*/{{.CLI_ARGS}}
     cmds:
       - cmd: |
-          for comp in ./components/*; do
-            cp -v ./mixins/{{.CLI_ARGS}}  $comp/{{.CLI_ARGS}}
-          done;
+          find ./components -type d \( -name .terraform -o -name .terragrunt-cache \) -prune -o -type f -name {{.CLI_ARGS}} -print | while IFS= read -r dest; do
+            cp -v ./mixins/{{.CLI_ARGS}} "$dest"
+          done
         silent: true
 
   pull-sops:

--- a/lib/mixins/Taskfile.yml
+++ b/lib/mixins/Taskfile.yml
@@ -2,19 +2,25 @@ version: "3"
 
 tasks:
   update-all:
-    # Updates (by overwriting) every existing copy of the named mixin under
-    # ./components/ with the current ./mixins/<file> template.
+    # Updates (by overwriting) every existing copy of the named mixin found
+    # recursively under the user's working directory with the current
+    # ./mixins/<file> template.
     #
     # Directories opt in to a mixin by having a copy of it on disk; this task only
-    # touches directories that already contain <file>. It does NOT add the mixin
-    # to directories that don't already have it — adopt a mixin in a new component
-    # by copying it in manually first as it needs to be an explicit choice, then
-    # future `update-all` runs will keep it in sync.
+    # touches files that already exist. It does NOT add the mixin to directories
+    # that don't already have it — adopt a mixin in a new place by copying it in
+    # manually first as it needs to be an explicit choice, then future
+    # `update-all` runs will keep it in sync.
     #
-    # `.terraform/` and `.terragrunt-cache/` are pruned so we don't overwrite the
-    # mixin inside vendored child-module copies that Terraform/Terragrunt drop on
-    # disk during init.
-    desc: "Update (by overwriting) every existing copy of a mixin under ./components/ with the current template. Does not add the mixin to directories that don't already have it. Example: `task mixins:update-all -- context.tf`."
+    # This intentionally searches the whole working directory so a single run
+    # keeps the mixin in sync across every consumer in the repo (root modules,
+    # in-repo child modules, etc.).
+    #
+    # `.terraform/`, `.terragrunt-cache/`, and the source `./mixins/` directory
+    # are pruned so we don't overwrite the mixin inside vendored child-module
+    # copies that Terraform/Terragrunt drop on disk during init, and we don't
+    # try to copy the source mixin onto itself.
+    desc: "Update (by overwriting) every existing copy of a mixin found recursively under the current directory with the current template. Picks up every consumer in the repo (root modules, in-repo child modules, etc.). Does not add the mixin to directories that don't already have it. Example: `task mixins:update-all -- context.tf`."
     dir: "{{.USER_WORKING_DIR}}"
     preconditions:
       - sh: test -f ./mixins/{{.CLI_ARGS}}
@@ -23,7 +29,7 @@ tasks:
       - ./mixins/{{.CLI_ARGS}}
     cmds:
       - cmd: |
-          find ./components -type d \( -name .terraform -o -name .terragrunt-cache \) -prune -o -type f -name {{.CLI_ARGS}} -print | while IFS= read -r dest; do
+          find . \( -type d \( -name .terraform -o -name .terragrunt-cache \) -o -path ./mixins \) -prune -o -type f -name {{.CLI_ARGS}} -print | while IFS= read -r dest; do
             cp -v ./mixins/{{.CLI_ARGS}} "$dest"
           done
         silent: true

--- a/lib/mixins/Taskfile.yml
+++ b/lib/mixins/Taskfile.yml
@@ -9,8 +9,7 @@ tasks:
     # Directories opt in to a mixin by having a copy of it on disk; this task only
     # touches files that already exist. It does NOT add the mixin to directories
     # that don't already have it — adopt a mixin in a new place by copying it in
-    # manually first as it needs to be an explicit choice, then future
-    # `update-all` runs will keep it in sync.
+    # first as it needs to be an explicit choice.
     #
     # This intentionally searches the whole working directory so a single run
     # keeps the mixin in sync across every consumer in the repo (root modules,

--- a/lib/mixins/Taskfile.yml
+++ b/lib/mixins/Taskfile.yml
@@ -19,8 +19,6 @@ tasks:
     preconditions:
       - sh: test -f ./mixins/{{.CLI_ARGS}}
         msg: "File does not exist: ./mixins/{{.CLI_ARGS}}"
-      - sh: test -d ./components
-        msg: ./components/ directory does not exist.
     sources:
       - ./mixins/{{.CLI_ARGS}}
     cmds:


### PR DESCRIPTION
Closes #47.

## Summary

Make `mixins:update-all` recurse from the user's working directory and only update existing copies of the mixin. Drops the hard-coded `./components/` scope so the task works in any consuming repo regardless of layout, and a single run keeps the mixin in sync across every consumer (root modules, in-repo child modules, etc.).

## Approach

- Find existing copies of the mixin recursively from the current working directory and overwrite in place.
  - REASON BEING: A given mixin isn't universal — e.g. `secrets.sops.tf` only belongs in certain modules that consume SOPS. Copying it everywhere creates unused files that have to be deleted by hand. Existing presence on disk is the opt-in signal.
- Search from `.` (the user's working directory) rather than `./components/`, so the task works in repos that don't follow a `./components/` layout, and so a single run also keeps in-repo child modules in sync — not just top-level components.
- Prune `.terraform/`, `.terragrunt-cache/`, and the source `./mixins/` directory so vendored child-module copies aren't overwritten and we don't try to copy the source mixin onto itself.

## Test plan

Validated end-to-end against the internal `mp-infra-spacelift-automation` Terraform infra repo (`masterpoint-internal/mp-infra-spacelift-automation`), which has both a flat-and-nested root-module layout AND in-repo child modules that consume the same `context.tf` mixin from CloudPosse null-label. The same logic was first applied to that repo's local `taskfiles/mixins/Taskfile.yml` override and exercised before being ported here.

Commands run in `mp-infra-spacelift-automation`:

```sh
# Inventory after the prune change — picks up child-modules too
$ find . \( -type d \( -name .terraform -o -name .terragrunt-cache \) -o -path ./mixins \) -prune -o -type f -name context.tf -print | wc -l
26     # 24 root modules + 2 child modules

# Execute (--force because Task's source/generates cache would otherwise report up-to-date)
$ task --force l:mixins:update -- context
./mixins/context.tf.tpl -> ./root-modules/aws-iam/delegated-tf-role/context.tf
./mixins/context.tf.tpl -> ./root-modules/aws-iam/primary-tf-role/context.tf
./mixins/context.tf.tpl -> ./root-modules/demo/rds/context.tf
... 23 more lines ...
./mixins/context.tf.tpl -> ./child-modules/demo-rds/context.tf
./mixins/context.tf.tpl -> ./child-modules/demo-kms-key/context.tf
```

Verified:

- [x] **Nested root-module instances picked up.** All three nested instances (`aws-iam/delegated-tf-role`, `aws-iam/primary-tf-role`, `demo/rds`) appeared in the `cp -v` output.
- [x] **In-repo child modules picked up.** Both `child-modules/demo-kms-key/context.tf` and `child-modules/demo-rds/context.tf` were updated, which the previous `./components/`-scoped version would have missed. This is the headline benefit of the recursive search.
- [x] **Existing copies only.** `context.tf` was overwritten in exactly the 26 directories that already had one on disk. Root modules without a `context.tf` (e.g. `aws-organization`, `github-organization-secrets`, `github-repositories`, `tfstate-backend`) were left untouched. `git status` showed no new files added.
- [x] **Source `./mixins/` pruned.** `mixins/context.tf.tpl` was confirmed unchanged after the run, so we didn't walk into the template source directory or attempt a self-copy.
- [x] **`.terraform/` pruned.** A raw recursive scan would otherwise hit ~165 vendored `main.tf` entries; no mixin files were written into `.terraform/` or `.terragrunt-cache/`.
- [x] **Precondition behavior.** Running with a non-existent mixin name fails cleanly with `File does not exist: ./mixins/<file>` and produces no copies.